### PR TITLE
feat: Studio loading UX + catalog->recipe gaps (2.2.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dsOMOPClient
 Type: Package
 Title: DataSHIELD Client for OMOP CDM Databases
-Version: 2.2.2
+Version: 2.2.3
 Authors@R: c(
     person("David", "Sarrat González", role = c("aut", "cre"), email = "david.sarrat@isglobal.org"),
     person("Xavier", "Escribà-Montagut", role = "aut"),

--- a/R/studio.R
+++ b/R/studio.R
@@ -139,6 +139,35 @@ ds.omop.studio <- function(symbol = "omop", launch.browser = TRUE) {
           $(document).on('click', '.achilles-disabled, .ohdsi-results-disabled', function(e) {
             e.preventDefault(); e.stopPropagation(); return false;
           });
+        ")),
+        # --- Startup loading overlay (shown immediately from the initial HTML,
+        # hidden when the server signals 'dsomop_ready' after the blocking
+        # federated catalog/status calls return). Robust to the synchronous
+        # nature of those calls — a server-output conditionalPanel would not
+        # render until after the block. ---
+        shiny::tags$style(shiny::HTML(
+          "#dsomop-loading{position:fixed;inset:0;z-index:20000;background:rgba(248,250,252,.97);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:14px;transition:opacity .45s ease}
+           #dsomop-loading.dsomop-hide{opacity:0;pointer-events:none}
+           #dsomop-loading .dsl-title{font:600 18px Inter,system-ui;color:#1e293b}
+           #dsomop-loading .dsl-sub{font:400 14px Inter,system-ui;color:#64748b}")),
+        shiny::tags$div(
+          id = "dsomop-loading",
+          shiny::tags$div(class = "spinner-border text-primary",
+                          style = "width:3rem;height:3rem;", role = "status"),
+          shiny::tags$div(class = "dsl-title", "Conectando con la federación…"),
+          shiny::tags$div(class = "dsl-sub",
+            "Cargando catálogo y estadísticas de los servidores")
+        ),
+        shiny::tags$script(shiny::HTML("
+          (function(){
+            var hidden=false;
+            function hide(){ if(hidden) return; hidden=true;
+              var el=document.getElementById('dsomop-loading');
+              if(el){ el.classList.add('dsomop-hide');
+                setTimeout(function(){ if(el&&el.parentNode) el.parentNode.removeChild(el); }, 520); } }
+            if(window.Shiny){ Shiny.addCustomMessageHandler('dsomop_ready', function(x){ hide(); }); }
+            setTimeout(hide, 90000); // safety net if the server never signals
+          })();
         "))
       ),
 
@@ -239,6 +268,9 @@ ds.omop.studio <- function(symbol = "omop", launch.browser = TRUE) {
           type = "error", duration = 10
         )
       })
+      # Dismiss the startup overlay once the (blocking) federated catalog/status
+      # calls have returned — success or error.
+      session$sendCustomMessage("dsomop_ready", TRUE)
     })
 
     # Clipboard toast is now handled entirely in JS (no round-trip needed)

--- a/R/studio_explore.R
+++ b/R/studio_explore.R
@@ -293,7 +293,12 @@
         return(.empty_state_ui("chart-simple", "No concepts found",
           "Select a table and run the query."))
       }
-      DT::DTOutput(ns("results_dt"))
+      shiny::tagList(
+        shiny::p(class = "text-muted small mb-2",
+          shiny::icon("hand-pointer"),
+          " Tick the checkbox in the first column to select concepts, then click +Extract or Filter."),
+        DT::DTOutput(ns("results_dt"))
+      )
     })
 
     output$results_dt <- DT::renderDT({
@@ -336,7 +341,8 @@
           "});",
           # Select-all header checkbox
           "var hdr = $('<input type=\"checkbox\" class=\"dt-chk-all\">');",
-          "$(table.column(0).header()).empty().append(hdr);",
+          "$(table.column(0).header()).empty().append(hdr)",
+          "  .append('<span class=\"ms-1 small text-muted\">Select</span>');",
           "hdr.on('change', function() {",
           "  var checked = this.checked;",
           "  sel = [];",
@@ -398,6 +404,7 @@
       idx <- idx[idx <= nrow(df)]
       tbl <- input$table
       added <- 0L
+      errors <- character(0)
       for (i in idx) {
         cid <- as.integer(df$concept_id[i])
         cname <- if ("concept_name" %in% names(df))
@@ -409,12 +416,17 @@
           )
           state$recipe <- recipe_add_variable(state$recipe, v)
           added <- added + 1L
-        }, error = function(e) NULL)
+        }, error = function(e) {
+          errors <<- c(errors, .clean_ds_error(e))
+        })
       }
       if (added > 0) {
         shiny::showNotification(
           paste("Added", added, "variable(s) to recipe"),
           type = "message", duration = 2)
+      }
+      for (msg in unique(errors)) {
+        shiny::showNotification(msg, type = "error")
       }
     })
 
@@ -429,6 +441,7 @@
       idx <- idx[idx <= nrow(df)]
       tbl <- input$table
       added <- 0L
+      errors <- character(0)
       for (i in idx) {
         cid <- as.integer(df$concept_id[i])
         cname <- if ("concept_name" %in% names(df))
@@ -437,12 +450,17 @@
           f <- omop_filter_has_concept(cid, tbl, cname)
           state$recipe <- recipe_add_filter(state$recipe, f)
           added <- added + 1L
-        }, error = function(e) NULL)
+        }, error = function(e) {
+          errors <<- c(errors, .clean_ds_error(e))
+        })
       }
       if (added > 0) {
         shiny::showNotification(
           paste("Added", added, "filter(s) to recipe"),
           type = "message", duration = 2)
+      }
+      for (msg in unique(errors)) {
+        shiny::showNotification(msg, type = "error")
       }
     })
 
@@ -487,14 +505,7 @@
       shiny::hr(),
       shiny::actionButton(ns("add_to_set"), "Add to Concept Set",
                           class = "btn-outline-primary btn-sm w-100 mb-1"),
-      shiny::actionButton(ns("add_to_recipe_extract"),
-                          shiny::tagList(shiny::icon("plus"), "Extract to Builder"),
-                          class = "btn-success text-white btn-sm w-100 mb-1"),
-      shiny::actionButton(ns("add_to_recipe_filter"),
-                          shiny::tagList(shiny::icon("filter"), "Filter in Builder"),
-                          class = "btn-warning text-white btn-sm w-100 mb-1"),
-      shiny::actionButton(ns("add_to_plan"), "Add to Plan",
-                          class = "btn-outline-info btn-sm w-100 mb-1"),
+      shiny::uiOutput(ns("recipe_actions")),
       shiny::actionButton(ns("reload"), "Reload",
                           icon = shiny::icon("rotate-right"),
                           class = "btn-outline-secondary btn-sm w-100")
@@ -650,6 +661,28 @@
           shiny::span(class = "text-muted", style = "font-size:0.78rem;",
             tbl)
         )
+      )
+    })
+
+    # Recipe/plan action buttons: enabled only when a concept is selected
+    output$recipe_actions <- shiny::renderUI({
+      has_concept <- !is.null(state$selected_concept_id) &&
+        !is.null(state$selected_table)
+      disabled_attr <- if (has_concept) NULL else "disabled"
+      shiny::tagList(
+        shiny::actionButton(session$ns("add_to_recipe_extract"),
+                            shiny::tagList(shiny::icon("plus"), "Extract to Builder"),
+                            class = "btn-success text-white btn-sm w-100 mb-1",
+                            disabled = disabled_attr),
+        shiny::actionButton(session$ns("add_to_recipe_filter"),
+                            shiny::tagList(shiny::icon("filter"), "Filter in Builder"),
+                            class = "btn-warning text-white btn-sm w-100 mb-1",
+                            disabled = disabled_attr),
+        shiny::actionButton(session$ns("add_to_plan"), "Add to Plan",
+                            class = "btn-outline-info btn-sm w-100 mb-1",
+                            disabled = disabled_attr),
+        if (!has_concept) shiny::p(class = "text-muted small mb-1",
+          "Drill into a concept from Prevalence first.")
       )
     })
 
@@ -1030,9 +1063,17 @@
       bslib::card_header(
         class = "d-flex justify-content-between align-items-center py-2",
         shiny::span("Concept Locator"),
-        shiny::actionButton(ns("locate_btn"), "Locate",
-                            icon = shiny::icon("location-dot"),
-                            class = "btn-sm btn-primary")
+        shiny::div(
+          bslib::tooltip(
+            shiny::actionButton(ns("extract_to_recipe"),
+                                shiny::tagList(shiny::icon("plus"), "Extract to recipe"),
+                                class = "btn-sm btn-success text-white me-1"),
+            "Add the selected concepts as variables to Builder"
+          ),
+          shiny::actionButton(ns("locate_btn"), "Locate",
+                              icon = shiny::icon("location-dot"),
+                              class = "btn-sm btn-primary")
+        )
       ),
       bslib::card_body(
         class = "py-2 px-3",
@@ -1234,6 +1275,63 @@
       })
     })
 
+    # +Extract: add selected concepts as variables to recipe
+    shiny::observeEvent(input$extract_to_recipe, {
+      items <- selected_ids()
+      if (length(items) == 0) {
+        shiny::showNotification("Add at least one concept above.",
+                                type = "warning")
+        return()
+      }
+      # Use the presence matrix (if located) to map concept_id -> table.
+      loc <- locate_data()
+      table_for <- function(cid) {
+        if (is.data.frame(loc) && "concept_id" %in% names(loc) &&
+            "table_name" %in% names(loc)) {
+          hit <- loc$table_name[loc$concept_id == cid]
+          hit <- hit[!is.na(hit) & nchar(as.character(hit)) > 0]
+          if (length(hit) > 0) return(as.character(hit[1]))
+        }
+        NULL
+      }
+      added <- 0L
+      errors <- character(0)
+      skipped <- 0L
+      for (item in items) {
+        cid <- as.integer(item$concept_id)
+        tbl <- table_for(cid)
+        if (is.null(tbl)) {
+          skipped <- skipped + 1L
+          next
+        }
+        cname <- item$concept_name
+        tryCatch({
+          v <- omop_variable(
+            table = tbl, concept_id = cid,
+            concept_name = cname, format = "raw"
+          )
+          state$recipe <- recipe_add_variable(state$recipe, v)
+          added <- added + 1L
+        }, error = function(e) {
+          errors <<- c(errors, .clean_ds_error(e))
+        })
+      }
+      if (added > 0) {
+        shiny::showNotification(
+          paste("Added", added, "variable(s) to recipe"),
+          type = "message", duration = 2)
+      }
+      if (skipped > 0) {
+        shiny::showNotification(
+          paste(skipped, "concept(s) skipped: no table located.",
+                "Click Locate first to map concepts to tables."),
+          type = "warning")
+      }
+      for (msg in unique(errors)) {
+        shiny::showNotification(msg, type = "error")
+      }
+    })
+
     # Re-extract on scope/server change
     shiny::observeEvent(list(state$scope, state$selected_servers), {
       res <- raw_locate_result()
@@ -1379,7 +1477,12 @@
         return(.empty_state_ui("book", "No results",
           "Search for concepts using the sidebar controls."))
       }
-      DT::DTOutput(ns("results_table"))
+      shiny::tagList(
+        shiny::p(class = "text-muted small mb-2",
+          shiny::icon("hand-pointer"),
+          " Tick the checkbox in the first column to select concepts, then click +Extract."),
+        DT::DTOutput(ns("results_table"))
+      )
     })
 
     output$results_table <- DT::renderDT({
@@ -1424,7 +1527,8 @@
           "  Shiny.setInputValue('", ns("vocab_chk_selected"), "', sel, {priority:'event'});",
           "});",
           "var hdr = $('<input type=\"checkbox\" class=\"dt-chk-all\">');",
-          "$(table.column(0).header()).empty().append(hdr);",
+          "$(table.column(0).header()).empty().append(hdr)",
+          "  .append('<span class=\"ms-1 small text-muted\">Select</span>');",
           "hdr.on('change', function() {",
           "  var checked = this.checked;",
           "  sel = [];",
@@ -1469,6 +1573,7 @@
       }
       idx <- idx[idx <= nrow(df)]
       added <- 0L
+      errors <- character(0)
       for (i in idx) {
         cid <- as.integer(df$concept_id[i])
         cname <- if ("concept_name" %in% names(df))
@@ -1484,12 +1589,17 @@
           )
           state$recipe <- recipe_add_variable(state$recipe, v)
           added <- added + 1L
-        }, error = function(e) NULL)
+        }, error = function(e) {
+          errors <<- c(errors, .clean_ds_error(e))
+        })
       }
       if (added > 0) {
         shiny::showNotification(
           paste("Added", added, "variable(s) to recipe"),
           type = "message", duration = 2)
+      }
+      for (msg in unique(errors)) {
+        shiny::showNotification(msg, type = "error")
       }
     })
 
@@ -1702,7 +1812,10 @@
       shiny::selectInput(ns("value_column"), "Value column",
                          choices = c("(auto-detect)" = "")),
       shiny::actionButton(ns("run_btn"), "Run", icon = shiny::icon("play"),
-                          class = "btn-primary w-100")
+                          class = "btn-primary w-100"),
+      shiny::actionButton(ns("extract_to_recipe"),
+                          shiny::tagList(shiny::icon("plus"), "Extract to recipe"),
+                          class = "btn-success text-white w-100 mt-1")
     ),
     shiny::uiOutput(ns("header")),
     bslib::card(full_screen = TRUE,
@@ -1759,6 +1872,30 @@
             NULL
           })
         res_rv(res)
+      })
+    })
+
+    # +Extract: add the looked-up concept as a variable to recipe
+    shiny::observeEvent(input$extract_to_recipe, {
+      shiny::req(input$table)
+      pc <- picked_concept()
+      cid <- if (is.list(pc)) pc$concept_id else pc
+      if (is.null(cid) || length(cid) == 0) {
+        shiny::showNotification("Pick a concept first.", type = "warning")
+        return()
+      }
+      cname <- if (is.list(pc)) pc$concept_name else NULL
+      tryCatch({
+        v <- omop_variable(
+          table = input$table, concept_id = as.integer(cid),
+          concept_name = cname, format = "raw"
+        )
+        state$recipe <- recipe_add_variable(state$recipe, v)
+        shiny::showNotification(
+          paste("Added", v$name, "to recipe"),
+          type = "message", duration = 2)
+      }, error = function(e) {
+        shiny::showNotification(.clean_ds_error(e), type = "error")
       })
     })
 

--- a/R/studio_overview.R
+++ b/R/studio_overview.R
@@ -317,7 +317,7 @@
     raw_coverage <- shiny::reactiveVal(NULL)
     coverage_data <- shiny::reactiveVal(NULL)
 
-    shiny::observeEvent(input$coverage_btn, {
+    .load_coverage <- function() {
       shiny::withProgress(message = "Loading domain coverage...", value = 0.3, {
         tryCatch({
           res <- ds.omop.domain.coverage(symbol = state$symbol)
@@ -337,7 +337,13 @@
             paste("Error:", conditionMessage(e)), type = "error")
         })
       })
-    })
+    }
+    shiny::observeEvent(input$coverage_btn, { .load_coverage() })
+    # Preload once the catalog is ready, so the panel is populated on entry
+    # (no click needed).
+    shiny::observeEvent(state$tables, {
+      if (!is.null(state$tables)) .load_coverage()
+    }, once = TRUE, ignoreNULL = TRUE)
 
     .update_coverage_server <- function(session, srv_names) {
       choices <- c("All Servers" = "__all__", stats::setNames(srv_names, srv_names))
@@ -400,7 +406,7 @@
       }
     })
 
-    shiny::observeEvent(input$miss_btn, {
+    .load_miss <- function() {
       shiny::withProgress(message = "Checking missingness...", value = 0.3, {
         tryCatch({
           res <- ds.omop.missingness(input$miss_table,
@@ -420,7 +426,13 @@
             paste("Error:", conditionMessage(e)), type = "error")
         })
       })
-    })
+    }
+    shiny::observeEvent(input$miss_btn, { .load_miss() })
+    # Preload once the table dropdown is auto-filled (mirrors Domain Coverage),
+    # so the panel is populated on entry (no click needed).
+    shiny::observeEvent(input$miss_table, {
+      if (!is.null(input$miss_table) && nzchar(input$miss_table)) .load_miss()
+    }, once = TRUE, ignoreNULL = TRUE)
 
     .update_miss_server <- function(session, srv_names) {
       choices <- c("All Servers" = "__all__", stats::setNames(srv_names, srv_names))


### PR DESCRIPTION
## Summary
Fixes the OMOP Studio "empty on entry" UX and the catalog→recipe gaps surfaced in a full functional review. Version 2.2.2 → 2.2.3. Client-side only.

**Loading / preload / cache**
- Startup loading overlay ("Conectando con la federación…") from the initial HTML, dismissed when the server signals ready (robust to the blocking federated calls).
- Overview Domain Coverage + Missingness auto-load on session start; catalog/status cached in session state (instant tab navigation).

**Explore catalog → recipe**
- `+Extract`/`+Filter` now surface errors (no more silent `tryCatch(...)→NULL`).
- "Tick the checkbox in the first column" hint on the Prevalence/Vocabulary concept tables.
- Drilldown recipe actions disabled (with helper note) until a concept is drilled.
- New "+ Extract to recipe" on the previously dead-end **Locator** and **Concept Summary** views.

## Verification
- `devtools::test()`: **PASS 1215 / FAIL 0**.
- Live federation: recipe **export (YAML/JSON/R-code) → import → recipe_to_plan → execute** downloads data to the session (nairobi 4666 / douala 3916 / dakar 3859 rows) with `value_as_concept_id` translated (11/11 round-trip checks pass).
- Visually confirmed on the live Studio: overlay → populated Overview; Locator + Concept Summary extract buttons.