### PR TITLE
Studio UX: fix blank Explore tabs (query_cache reactive bug), empties, spinners (2.3.8)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dsOMOPClient
 Type: Package
 Title: DataSHIELD Client for OMOP CDM Databases
-Version: 2.3.5
+Version: 2.3.8
 Authors@R: c(
     person("David", "Sarrat González", role = c("aut", "cre"), email = "david.sarrat@isglobal.org"),
     person("Xavier", "Escribà-Montagut", role = "aut"),
@@ -29,7 +29,8 @@ Imports:
     jsonlite,
     yaml,
     plotly,
-    fontawesome
+    fontawesome,
+    shinycssloaders
 Suggests:
     DSLite,
     dsBaseClient,
@@ -39,8 +40,7 @@ Suggests:
     clipr,
     knitr,
     rmarkdown,
-    visNetwork,
-    shinycssloaders
+    visNetwork
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 RoxygenNote: 7.3.3

--- a/R/exploration.R
+++ b/R/exploration.R
@@ -240,6 +240,13 @@ ds.omop.concept.prevalence <- function(table, concept_col = NULL,
 #' @param value_col Character; the numeric column to histogram (e.g.,
 #'   \code{"value_as_number"}).
 #' @param bins Integer; the number of histogram bins (default: 20).
+#' @param concept_id Integer or NULL; optional concept ID to restrict rows to a
+#'   single concept of the table before binning (e.g. \code{value_as_number}
+#'   for one measurement concept). Default: NULL for all rows. The server
+#'   applies the same disclosure controls to the concept-filtered population.
+#'   Requires a dsOMOP server build with histogram concept scoping; older
+#'   servers reject the argument (the Studio falls back to the box plot and
+#'   percentile table, which are concept-scoped via the quantiles aggregate).
 #' @param cohort_table Character; name of a server-side cohort temp table
 #'   for filtering, or NULL (default: NULL).
 #' @param window List with \code{start}/\code{end} date strings for
@@ -263,6 +270,7 @@ ds.omop.concept.prevalence <- function(table, concept_col = NULL,
 #' }
 #' @export
 ds.omop.value.histogram <- function(table, value_col, bins = 20L,
+                                     concept_id = NULL,
                                      cohort_table = NULL, window = NULL,
                                      scope = c("per_site", "pooled"),
                                      pooling_policy = "strict",
@@ -272,7 +280,7 @@ ds.omop.value.histogram <- function(table, value_col, bins = 20L,
 
   code <- .build_code("ds.omop.value.histogram",
     table = table, value_col = value_col, bins = bins,
-    cohort_table = cohort_table, window = window,
+    concept_id = concept_id, cohort_table = cohort_table, window = window,
     scope = scope, symbol = symbol)
 
   if (!execute) {
@@ -287,14 +295,27 @@ ds.omop.value.histogram <- function(table, value_col, bins = 20L,
   pooled <- NULL
   warnings <- character(0)
 
+  # Only pass concept_id when set, so the unfiltered path stays byte-for-byte
+  # compatible with servers that predate histogram concept scoping (they would
+  # reject an extra concept_id = NULL argument). When a concept IS requested
+  # the call requires a server build with concept scoping.
+  .hist_call <- function(...) {
+    args <- list("omopNumericHistogramDS", session$res_symbol,
+                 table, value_col, as.integer(bins), cohort_table, window, ...)
+    if (!is.null(concept_id)) args$concept_id <- concept_id
+    do.call(call, args)
+  }
+  .range_call <- function() {
+    args <- list("omopNumericRangeDS", session$res_symbol,
+                 table, value_col, cohort_table, window)
+    if (!is.null(concept_id)) args$concept_id <- concept_id
+    do.call(call, args)
+  }
+
   if (scope == "pooled") {
     # Two-pass pooling: compute shared bin edges across servers
     # Pass 1: Get p05/p95 ranges from each server
-    range_raw <- .ds_safe_aggregate(
-      conns,
-      expr = call("omopNumericRangeDS", session$res_symbol,
-                  table, value_col, cohort_table, window)
-    )
+    range_raw <- .ds_safe_aggregate(conns, expr = .range_call())
 
     # Compute shared breaks from global p05/p95
     p05s <- vapply(range_raw, function(s) {
@@ -312,24 +333,15 @@ ds.omop.value.histogram <- function(table, value_col, bins = 20L,
       shared_breaks <- seq(global_p05, global_p95, length.out = as.integer(bins) + 1L)
 
       # Pass 2: Histogram with shared breaks
-      raw <- .ds_safe_aggregate(
-        conns,
-        expr = call("omopNumericHistogramDS", session$res_symbol,
-                    table, value_col, as.integer(bins),
-                    cohort_table, window, .ds_encode(shared_breaks))
-      )
+      raw <- .ds_safe_aggregate(conns,
+        expr = .hist_call(.ds_encode(shared_breaks)))
 
       pool_out <- .pool_result(raw, "histogram", pooling_policy)
       pooled <- pool_out$result
       warnings <- pool_out$warnings
     } else {
       # Fallback: single-pass (ranges are degenerate)
-      raw <- .ds_safe_aggregate(
-        conns,
-        expr = call("omopNumericHistogramDS", session$res_symbol,
-                    table, value_col, as.integer(bins),
-                    cohort_table, window)
-      )
+      raw <- .ds_safe_aggregate(conns, expr = .hist_call())
       pool_out <- .pool_result(raw, "histogram", pooling_policy)
       pooled <- pool_out$result
       warnings <- c(pool_out$warnings,
@@ -337,12 +349,7 @@ ds.omop.value.histogram <- function(table, value_col, bins = 20L,
     }
   } else {
     # Per-site: single pass (no pooling needed)
-    raw <- .ds_safe_aggregate(
-      conns,
-      expr = call("omopNumericHistogramDS", session$res_symbol,
-                  table, value_col, as.integer(bins),
-                  cohort_table, window)
-    )
+    raw <- .ds_safe_aggregate(conns, expr = .hist_call())
   }
 
   dsomop_result(
@@ -658,6 +665,11 @@ ds.omop.concept.drilldown <- function(table, concept_id,
 #'   summarised.
 #' @param scope Character; \code{"per_site"} (default) or \code{"pooled"}.
 #'   Passed through to the underlying calls.
+#' @param pooling_policy Character; \code{"strict"} (default) or
+#'   \code{"pooled_only_ok"} (Best Effort). Passed through to the underlying
+#'   value-counts, column-stats and quantile calls so that, when pooled,
+#'   categories/values present on only some sites are summed across the
+#'   available sites rather than suppressed.
 #' @param symbol Character; the session symbol (default: \code{"omop"}).
 #' @param conns DSI connection object(s) or NULL to use the session default.
 #' @return A named list with \code{table}, \code{concept_id},
@@ -681,6 +693,7 @@ ds.omop.concept.drilldown <- function(table, concept_id,
 #' @export
 ds.omop.concept.summary <- function(table, concept_id, column = NULL,
                                     scope = c("per_site", "pooled"),
+                                    pooling_policy = "strict",
                                     symbol = "omop", conns = NULL) {
   scope <- match.arg(scope)
 
@@ -705,15 +718,18 @@ ds.omop.concept.summary <- function(table, concept_id, column = NULL,
     if (grepl("_concept_id$", col)) {
       categorical[[col]] <- ds.omop.value.counts(
         table, col, concept_id = concept_id,
-        scope = scope, symbol = symbol, conns = conns)
+        scope = scope, pooling_policy = pooling_policy,
+        symbol = symbol, conns = conns)
     } else {
       numeric[[col]] <- list(
         stats = ds.omop.column.stats(
           table, col, concept_id = concept_id,
-          scope = scope, symbol = symbol, conns = conns),
+          scope = scope, pooling_policy = pooling_policy,
+          symbol = symbol, conns = conns),
         quantiles = ds.omop.value.quantiles(
           table, col, concept_id = concept_id,
-          scope = scope, symbol = symbol, conns = conns))
+          scope = scope, pooling_policy = pooling_policy,
+          symbol = symbol, conns = conns))
     }
   }
 

--- a/R/studio.R
+++ b/R/studio.R
@@ -154,9 +154,9 @@ ds.omop.studio <- function(symbol = "omop", launch.browser = TRUE) {
           id = "dsomop-loading",
           shiny::tags$div(class = "spinner-border text-primary",
                           style = "width:3rem;height:3rem;", role = "status"),
-          shiny::tags$div(class = "dsl-title", "Conectando con la federación…"),
+          shiny::tags$div(class = "dsl-title", "Connecting to the federation…"),
           shiny::tags$div(class = "dsl-sub",
-            "Cargando catálogo y estadísticas de los servidores")
+            "Loading catalogue and server statistics")
         ),
         shiny::tags$script(shiny::HTML("
           (function(){
@@ -247,10 +247,15 @@ ds.omop.studio <- function(symbol = "omop", launch.browser = TRUE) {
       plan_outputs = list(),
       script_lines = character(0),
       scope = "pooled",
-      pooling_policy = "strict",
+      pooling_policy = "pooled_only_ok",
       server_names = character(0),
       selected_servers = character(0),
-      history = list()
+      history = list(),
+      # Session-scoped memoisation cache for federated query results. The
+      # federation data is static for the life of a Studio session, so caching
+      # by (fn, table, column/concept, scope, policy, servers) lets revisiting
+      # a tab or repeating a query return instantly without re-querying.
+      query_cache = new.env(parent = emptyenv())
     )
 
     # Load initial data on startup
@@ -1078,6 +1083,122 @@ isTRUE_vec <- function(x) {
   combined
 }
 
+# Display-data extractor with a disclosure-safe pooled fallback.
+#
+# Under scope == "pooled" with strict pooling, a value absent on ANY site is
+# suppressed (NA) and the tabs then drop those rows — which can leave the whole
+# table blank even though real per-site data exists. This wrapper detects that
+# case: when the pooled frame is empty / all-NA in `count_cols` but the per-site
+# data is not, it returns the row-bound per-site ("all") view instead and tags
+# the result with attr "pooled_fallback" = TRUE so the tab can render a banner.
+# Summing already-suppressed per-site cells is never done here (we only fall
+# back to per-site-labelled rows), so disclosure safety is preserved.
+.explore_display <- function(res, scope, selected_server = NULL,
+                             count_cols = character(0), server_col = "server") {
+  if (is.null(res)) return(NULL)
+  df <- .extract_display_data(res, scope, selected_server,
+                              server_col = server_col)
+
+  if (!identical(scope, "pooled") || !inherits(res, "dsomop_result"))
+    return(df)
+
+  # Is the pooled frame effectively empty (no rows, or all count cells NA)?
+  pooled_empty <- is.null(df) || !is.data.frame(df) || nrow(df) == 0
+  if (!pooled_empty && length(count_cols) > 0) {
+    cc <- intersect(count_cols, names(df))
+    if (length(cc) > 0) {
+      pooled_empty <- all(vapply(cc, function(c) all(is.na(df[[c]])),
+                                 logical(1)))
+    }
+  }
+  if (!pooled_empty) return(df)
+
+  # Fall back to the row-bound per-site view (real, per-site-labelled data).
+  alt <- .extract_display_data(res, "all", selected_server,
+                               server_col = server_col)
+  if (is.null(alt) || !is.data.frame(alt) || nrow(alt) == 0) return(df)
+  attr(alt, "pooled_fallback") <- TRUE
+  alt
+}
+
+# Banner shown above a results table when strict pooling suppressed every cell
+# and the tab is displaying the per-site view as a fallback (see
+# .explore_display). Tabs call this with the displayed data frame.
+.pooled_fallback_banner <- function(df) {
+  if (is.null(df) || !isTRUE(attr(df, "pooled_fallback"))) return(NULL)
+  shiny::div(class = "alert alert-warning py-2 mb-2", role = "alert",
+    shiny::icon("triangle-exclamation"),
+    shiny::strong(" Strict pooling suppressed all pooled cells "),
+    "(these values are not present on every site). Showing per-site results ",
+    "instead. Switch the sidebar Pooling Policy to ", shiny::strong("Best Effort"),
+    " or Data Scope to ", shiny::strong("Per Site"), " to pool across the ",
+    "available sites.")
+}
+
+# Session-scoped memoisation of a federated query. `state` holds the cache
+# environment; `key_parts` is a named list uniquely identifying the call
+# (function name, table, column/concept, scope, policy, ...). The selected
+# servers and the session symbol are folded into the key automatically so that
+# changing the server selection or reconnecting never returns a stale result.
+# `compute` is a zero-arg function that performs the actual (slow) query; it is
+# only invoked on a cache miss. NULL results are not cached (so a transient
+# failure can be retried). The federation data is static for the session, so
+# entries never expire.
+.cached_call <- function(state, key_parts, compute) {
+  # These reactiveValues fields are read imperatively: the caller may invoke us
+  # from a deferred session$onFlushed callback (OUTSIDE any reactive consumer),
+  # where a bare reactive read throws "Can't access reactive value ... outside
+  # of reactive consumer". isolate() makes the reads legal in both reactive and
+  # deferred contexts without taking a reactive dependency.
+  cache <- shiny::isolate(state$query_cache)
+  if (is.null(cache)) return(compute())
+  key_parts$.servers <- paste(sort(shiny::isolate(state$selected_servers) %||% character(0)),
+                              collapse = ",")
+  key_parts$.symbol <- shiny::isolate(state$symbol)
+  key <- .cache_key(key_parts)
+  if (exists(key, envir = cache, inherits = FALSE)) {
+    return(get(key, envir = cache, inherits = FALSE))
+  }
+  val <- compute()
+  if (!is.null(val)) assign(key, val, envir = cache)
+  val
+}
+
+# Run `expr` AFTER the current reactive flush completes, so any output state
+# set synchronously before this call (e.g. a result reactiveVal reset to NULL,
+# which puts a .with_spinner output into its recalculating/spinner state) is
+# painted to the client FIRST. This makes the loading spinner appear within one
+# flush (~tens of ms) instead of only after the blocking federated call
+# returns. Falls back to running inline if onFlushed is unavailable.
+.defer_after_flush <- function(session, expr) {
+  force(session)
+  # The deferred block runs inside session$onFlushed, OUTSIDE any reactive
+  # consumer, yet it reads reactiveValues (state$symbol, state$selected_servers,
+  # input$*) to build/run the query. Evaluate it inside isolate() so those reads
+  # are legal (the block is meant to run once, imperatively — not reactively).
+  fun <- function() shiny::isolate(expr)
+  if (!is.null(session) && is.function(session$onFlushed)) {
+    session$onFlushed(fun, once = TRUE)
+  } else {
+    fun()
+  }
+}
+
+# Build a deterministic cache key from a named list of scalar/short-vector
+# parts. The parts are flattened to "name=value" pairs in sorted-name order so
+# the key is stable regardless of argument order. NULLs become "name=" so that
+# concept_id = NULL and concept_id = 3027018 map to distinct keys.
+.cache_key <- function(parts) {
+  nms <- sort(names(parts))
+  flat <- vapply(nms, function(n) {
+    v <- parts[[n]]
+    sval <- if (is.null(v) || length(v) == 0) "" else
+      paste(as.character(v), collapse = "|")
+    paste0(n, "=", sval)
+  }, character(1))
+  paste0("k_", paste(flat, collapse = ";"))
+}
+
 .studio_colors <- c("#2563eb", "#059669", "#d97706", "#7c3aed", "#0891b2",
                     "#dc2626", "#65a30d", "#c026d3", "#ea580c", "#0d9488")
 
@@ -1124,6 +1245,17 @@ isTRUE_vec <- function(x) {
     shiny::h5(title),
     if (!is.null(desc)) shiny::p(desc)
   )
+}
+
+# Wrap a slow federated output in a loading spinner when shinycssloaders is
+# present; else return the bare output (no hard dependency). Mirrors the
+# .with_plan_spinner helper in studio_build.R but with a configurable caption.
+.with_spinner <- function(output, caption = "Loading…") {
+  if (requireNamespace("shinycssloaders", quietly = TRUE)) {
+    shinycssloaders::withSpinner(output, type = 8, caption = caption)
+  } else {
+    output
+  }
 }
 
 .history_add <- function(state, action) {

--- a/R/studio_explore.R
+++ b/R/studio_explore.R
@@ -100,7 +100,8 @@
         )
       ),
       bslib::card_body(
-        shiny::uiOutput(ns("results_content")),
+        .with_spinner(shiny::uiOutput(ns("results_content")),
+                      caption = "Running query…"),
         shiny::uiOutput(ns("scope_info"))
       )
     )
@@ -111,6 +112,7 @@
   shiny::moduleServer(id, function(input, output, session) {
     ns <- session$ns
     prevalence_data <- shiny::reactiveVal(NULL)
+    has_run <- shiny::reactiveVal(FALSE)
 
     # Populate table dropdown from state$tables
     shiny::observe({
@@ -235,18 +237,28 @@
     # Run concept prevalence
     shiny::observeEvent(input$run_btn, {
       shiny::req(input$table, input$concept_col)
+      has_run(TRUE)
 
       scope <- state$scope %||% "per_site"
       policy <- state$pooling_policy %||% "strict"
+      tbl <- input$table; ccol <- input$concept_col; metric <- input$metric
 
+      # Reset results NOW so the .with_spinner output paints its spinner in this
+      # flush; run the (blocking) federated query only after the flush.
+      prevalence_data(NULL)
+      last_result(NULL)
+      .defer_after_flush(session, {
       shiny::withProgress(message = "Fetching concept prevalence...", value = 0.3, {
         tryCatch({
-          res <- ds.omop.concept.prevalence(
-            table = input$table, concept_col = input$concept_col,
-            metric = input$metric, top_n = 99999L,
-            scope = .backend_scope(scope), pooling_policy = policy,
-            symbol = state$symbol
-          )
+          res <- .cached_call(state,
+            list(fn = "concept.prevalence", table = tbl, concept_col = ccol,
+                 metric = metric, scope = scope, policy = policy),
+            function() ds.omop.concept.prevalence(
+              table = tbl, concept_col = ccol,
+              metric = metric, top_n = 99999L,
+              scope = .backend_scope(scope), pooling_policy = policy,
+              symbol = state$symbol
+            ))
           shiny::incProgress(0.5)
           # Accumulate code for Script tab
           if (inherits(res, "dsomop_result") && nchar(res$meta$call_code) > 0) {
@@ -254,23 +266,27 @@
           }
           last_result(res)
 
-          # Extract display data based on scope
-          df <- .extract_display_data(res, scope, state$selected_servers,
-                                       intersect_only = FALSE)
+          # Extract display data based on scope (with disclosure-safe pooled
+          # fallback to per-site when strict pooling suppressed everything).
+          metric_col <- if (metric == "persons") "n_persons" else "n_records"
+          df <- .explore_display(res, scope, state$selected_servers,
+                                 count_cols = metric_col)
+          fb <- isTRUE(attr(df, "pooled_fallback"))
 
           # Remove disclosure-suppressed rows (NA in count columns)
           if (is.data.frame(df) && nrow(df) > 0) {
-            metric_col <- if (input$metric == "persons") "n_persons" else "n_records"
             if (metric_col %in% names(df)) {
               df <- df[!is.na(df[[metric_col]]), , drop = FALSE]
             }
           }
+          if (fb && is.data.frame(df)) attr(df, "pooled_fallback") <- TRUE
           prevalence_data(df)
         }, error = function(e) {
           shiny::showNotification(
             .clean_ds_error(e), type = "error"
           )
         })
+      })
       })
     })
 
@@ -280,16 +296,18 @@
       if (is.null(res)) return()
       scope <- state$scope %||% "per_site"
 
-      df <- .extract_display_data(res, scope, state$selected_servers,
-                                   intersect_only = FALSE)
+      metric_col <- if (input$metric == "persons") "n_persons" else "n_records"
+      df <- .explore_display(res, scope, state$selected_servers,
+                             count_cols = metric_col)
+      fb <- isTRUE(attr(df, "pooled_fallback"))
 
       # Remove disclosure-suppressed rows
       if (is.data.frame(df) && nrow(df) > 0) {
-        metric_col <- if (input$metric == "persons") "n_persons" else "n_records"
         if (metric_col %in% names(df)) {
           df <- df[!is.na(df[[metric_col]]), , drop = FALSE]
         }
       }
+      if (fb && is.data.frame(df)) attr(df, "pooled_fallback") <- TRUE
       prevalence_data(df)
     }, ignoreInit = TRUE)
 
@@ -302,10 +320,23 @@
     output$results_content <- shiny::renderUI({
       df <- prevalence_data()
       if (is.null(df) || !is.data.frame(df) || nrow(df) == 0) {
-        return(.empty_state_ui("chart-simple", "No concepts found",
-          "Select a table and run the query."))
+        if (!isTRUE(has_run())) {
+          return(.empty_state_ui("chart-simple", "Ready to explore",
+            "Choose a table and a concept column, then click Run."))
+        }
+        scope <- state$scope %||% "per_site"
+        policy <- state$pooling_policy %||% "strict"
+        if (identical(scope, "pooled") && identical(policy, "strict")) {
+          return(.empty_state_ui("chart-simple", "All cells suppressed",
+            paste0("Strict pooling suppressed every concept (none present on ",
+                   "all sites). Switch the sidebar Pooling Policy to Best ",
+                   "Effort, or Data Scope to Per Site.")))
+        }
+        return(.empty_state_ui("chart-simple", "No concepts",
+          "No concepts above the disclosure threshold for this selection."))
       }
       shiny::tagList(
+        .pooled_fallback_banner(df),
         shiny::p(class = "text-muted small mb-2",
           shiny::icon("hand-pointer"),
           " Tick the checkbox in the first column to select concepts, then click +Extract or Filter."),
@@ -1815,11 +1846,12 @@
     bslib::card_body(
       shiny::conditionalPanel(
         condition = sprintf("input['%s'] == 'chart'", ns(paste0(plot_id, "_view"))),
-        plotly::plotlyOutput(ns(plot_id), height = "320px")
+        .with_spinner(plotly::plotlyOutput(ns(plot_id), height = "320px"),
+                      caption = "Running query…")
       ),
       shiny::conditionalPanel(
         condition = sprintf("input['%s'] == 'table'", ns(paste0(plot_id, "_view"))),
-        DT::DTOutput(ns(dt_id))
+        .with_spinner(DT::DTOutput(ns(dt_id)), caption = "Running query…")
       )
     )
   )
@@ -1894,8 +1926,14 @@
 #' Heatmap from a (already-suppressed) cross-tab matrix; NA cells shown blank
 #' @keywords internal
 .explore_heatmap_plot <- function(M, title = NULL) {
-  if (is.null(M) || !is.matrix(M) || length(M) == 0) {
-    return(.plotly_no_data("No cross-tab data"))
+  if (is.null(M) || !is.matrix(M) || length(M) == 0 || all(is.na(M))) {
+    # All-NA = every cell disclosure-suppressed (typical for a pooled 2-way
+    # table on a small federation). Show a placeholder instead of letting
+    # plotly fail with "Wasn't able to determine range of 'domain'".
+    msg <- if (!is.null(M) && is.matrix(M) && length(M) > 0 && all(is.na(M)))
+      "All cells suppressed under pooled — switch Data Scope to Per Site"
+      else "No cross-tab data"
+    return(.plotly_no_data(msg))
   }
   .safe_plotly({
     txt <- matrix(ifelse(is.na(M), "—", as.character(M)),
@@ -1948,8 +1986,8 @@
       shiny::selectInput(ns("column"), "Column", choices = NULL),
       .concept_picker_ui(ns("concept"), label = "Concept filter (optional)"),
       shiny::p(class = "text-muted small",
-        "Filtra por un concepto para rankear sus valores ",
-        "(p.ej. los ritmos dentro de Heart rate rhythm)."),
+        "Filter by a concept to rank its values ",
+        "(e.g. the rhythms within Heart rate rhythm)."),
       shiny::numericInput(ns("top_n"), "Top N", value = 20, min = 5, max = 200,
                           step = 5),
       shiny::actionButton(ns("run_btn"), "Run", icon = shiny::icon("play"),
@@ -1984,20 +2022,28 @@
       shiny::updateSelectInput(session, "column", choices = cols)
     }, ignoreInit = TRUE)
 
+    has_run <- shiny::reactiveVal(FALSE)
     shiny::observeEvent(input$run_btn, {
       shiny::req(input$table, input$column)
+      has_run(TRUE)
       scope <- state$scope %||% "per_site"
       policy <- state$pooling_policy %||% "strict"
       pc <- picked_concept()
       cid <- if (is.list(pc)) pc$concept_id else pc
       cid <- if (is.null(cid) || length(cid) == 0) NULL else cid
+      tbl <- input$table; col <- input$column
+      topn <- as.integer(input$top_n %||% 20)
+      res_rv(NULL)
+      .defer_after_flush(session, {
       shiny::withProgress(message = "Counting values...", value = 0.4, {
         res <- tryCatch(
-          ds.omop.value.counts(table = input$table, column = input$column,
-                               top_n = as.integer(input$top_n %||% 20),
-                               concept_id = cid,
-                               scope = .backend_scope(scope),
-                               pooling_policy = policy, symbol = state$symbol),
+          .cached_call(state,
+            list(fn = "value.counts", table = tbl, column = col, top_n = topn,
+                 concept_id = cid, scope = scope, policy = policy),
+            function() ds.omop.value.counts(table = tbl, column = col,
+                                 top_n = topn, concept_id = cid,
+                                 scope = .backend_scope(scope),
+                                 pooling_policy = policy, symbol = state$symbol)),
           error = function(e) {
             shiny::showNotification(.clean_ds_error(e), type = "error"); NULL
           })
@@ -2006,29 +2052,48 @@
         }
         res_rv(res)
       })
+      })
     })
 
     .vr_df <- shiny::reactive({
       res <- res_rv()
       if (is.null(res)) return(NULL)
-      df <- .extract_display_data(res, state$scope %||% "per_site",
-                                  state$selected_servers)
+      cnt_cols <- intersect(c("n", "count"), names(.extract_display_data(
+        res, "per_site", state$selected_servers) %||% list()))
+      df <- .explore_display(res, state$scope %||% "per_site",
+                             state$selected_servers, count_cols = cnt_cols)
       if (!is.data.frame(df) || nrow(df) == 0) return(NULL)
+      fb <- isTRUE(attr(df, "pooled_fallback"))
       # Drop suppressed rows (count NA) from the displayed/charted frame.
       cnt <- if ("n" %in% names(df)) "n" else "count"
       if (cnt %in% names(df)) df <- df[!is.na(df[[cnt]]), , drop = FALSE]
       # Prefer concept_name label when available.
       lab <- if ("concept_name" %in% names(df)) "concept_name" else "value"
       keep <- intersect(c(lab, "value", "n", "count"), names(df))
-      df[, unique(keep), drop = FALSE]
+      out <- df[, unique(keep), drop = FALSE]
+      if (fb) attr(out, "pooled_fallback") <- TRUE
+      out
     })
 
     output$header <- shiny::renderUI({
-      if (is.null(.vr_df())) {
-        return(.empty_state_ui("ranking-star", "No values ranked",
-          "Pick a table and column, then click Run."))
+      df <- .vr_df()
+      if (is.null(df)) {
+        if (!isTRUE(has_run())) {
+          return(.empty_state_ui("ranking-star", "No values ranked",
+            "Pick a table and column, then click Run."))
+        }
+        scope <- state$scope %||% "per_site"
+        policy <- state$pooling_policy %||% "strict"
+        if (identical(scope, "pooled") && identical(policy, "strict")) {
+          return(.empty_state_ui("ranking-star", "All values suppressed",
+            paste0("Strict pooling suppressed every value (none present on all ",
+                   "sites). Switch Pooling Policy to Best Effort or Data Scope ",
+                   "to Per Site.")))
+        }
+        return(.empty_state_ui("ranking-star", "No values",
+          "No values above the disclosure threshold for this selection."))
       }
-      NULL
+      .pooled_fallback_banner(df)
     })
 
     output$vr_plot <- plotly::renderPlotly({
@@ -2059,6 +2124,11 @@
       title = "Numeric Distribution", width = 280, open = "always",
       shiny::selectInput(ns("table"), "Table", choices = NULL),
       shiny::selectInput(ns("value_col"), "Numeric column", choices = NULL),
+      .concept_picker_ui(ns("concept"), label = "Concept (required)"),
+      shiny::p(class = "text-muted small",
+        "Summarising a numeric column across a whole table mixes unrelated ",
+        "variables. Pick a numeric concept such as ",
+        shiny::tags$code("Heart rate (3027018)"), " to scope the distribution."),
       shiny::numericInput(ns("bins"), "Bins", value = 20, min = 5, max = 50,
                           step = 5),
       shiny::actionButton(ns("run_btn"), "Run", icon = shiny::icon("play"),
@@ -2069,8 +2139,9 @@
     bslib::card(full_screen = TRUE,
       bslib::card_header("Distribution (box from percentiles)"),
       bslib::card_body(
-        plotly::plotlyOutput(ns("num_box_plot"), height = "260px"),
-        DT::DTOutput(ns("num_quant_dt"))
+        .with_spinner(plotly::plotlyOutput(ns("num_box_plot"), height = "260px"),
+                      caption = "Running query…"),
+        .with_spinner(DT::DTOutput(ns("num_quant_dt")), caption = "Running query…")
       ))
   )
 }
@@ -2080,6 +2151,8 @@
   shiny::moduleServer(id, function(input, output, session) {
     hist_rv <- shiny::reactiveVal(NULL)
     quant_rv <- shiny::reactiveVal(NULL)
+    has_run <- shiny::reactiveVal(FALSE)
+    picked_concept <- .concept_picker_server("concept", state)
 
     shiny::observe({
       tbls <- .get_person_tables(state$tables)
@@ -2102,21 +2175,44 @@
 
     shiny::observeEvent(input$run_btn, {
       shiny::req(input$table, input$value_col)
+      pc <- picked_concept()
+      cid <- if (is.list(pc)) pc$concept_id else pc
+      cid <- if (is.null(cid) || length(cid) == 0) NULL else as.integer(cid)
+      # A concept is REQUIRED: summarising value_as_number across the whole
+      # table mixes unrelated measurements and is meaningless.
+      if (is.null(cid)) {
+        shiny::showNotification(
+          "Pick a numeric concept first (e.g. Heart rate, 3027018).",
+          type = "warning")
+        return()
+      }
+      has_run(TRUE)
       scope <- state$scope %||% "per_site"
       policy <- state$pooling_policy %||% "strict"
+      tbl <- input$table; vcol <- input$value_col
+      bins <- as.integer(input$bins %||% 20)
+      hist_rv(NULL); quant_rv(NULL)
+      .defer_after_flush(session, {
       shiny::withProgress(message = "Computing distribution...", value = 0.4, {
         h <- tryCatch(
-          ds.omop.value.histogram(table = input$table, value_col = input$value_col,
-            bins = as.integer(input$bins %||% 20),
-            scope = .backend_scope(scope), pooling_policy = policy,
-            symbol = state$symbol),
+          .cached_call(state,
+            list(fn = "value.histogram", table = tbl, value_col = vcol,
+                 bins = bins, concept_id = cid, scope = scope, policy = policy),
+            function() ds.omop.value.histogram(table = tbl, value_col = vcol,
+              bins = bins, concept_id = cid,
+              scope = .backend_scope(scope), pooling_policy = policy,
+              symbol = state$symbol)),
           error = function(e) {
             shiny::showNotification(.clean_ds_error(e), type = "error"); NULL
           })
         q <- tryCatch(
-          ds.omop.value.quantiles(table = input$table, value_col = input$value_col,
-            scope = .backend_scope(scope), pooling_policy = policy,
-            symbol = state$symbol),
+          .cached_call(state,
+            list(fn = "value.quantiles", table = tbl, value_col = vcol,
+                 concept_id = cid, scope = scope, policy = policy),
+            function() ds.omop.value.quantiles(table = tbl, value_col = vcol,
+              concept_id = cid,
+              scope = .backend_scope(scope), pooling_policy = policy,
+              symbol = state$symbol)),
           error = function(e) NULL)
         for (r in list(h, q)) {
           if (inherits(r, "dsomop_result") && nchar(r$meta$call_code) > 0) {
@@ -2124,6 +2220,7 @@
           }
         }
         hist_rv(h); quant_rv(q)
+      })
       })
     })
 
@@ -2159,9 +2256,22 @@
     })
 
     output$header <- shiny::renderUI({
+      pc <- picked_concept()
+      cid <- if (is.list(pc)) pc$concept_id else pc
+      has_concept <- !(is.null(cid) || length(cid) == 0)
       if (is.null(.hist_df()) && is.null(.quant_df())) {
-        return(.empty_state_ui("chart-area", "No distribution computed",
-          "Pick a table and numeric column, then click Run."))
+        if (!has_concept) {
+          return(.empty_state_ui("chart-area", "Pick a numeric concept",
+            paste0("Select a numeric concept such as Heart rate (3027018) to ",
+                   "scope the distribution, then click Run. Summarising the ",
+                   "whole column would mix unrelated variables.")))
+        }
+        if (!isTRUE(has_run())) {
+          return(.empty_state_ui("chart-area", "No distribution computed",
+            "Concept selected — click Run to compute the distribution."))
+        }
+        return(.empty_state_ui("chart-area", "No distribution",
+          "No values above the disclosure threshold for this concept."))
       }
       if (identical(state$scope %||% "per_site", "pooled")) {
         return(shiny::p(class = "text-muted small mb-2",
@@ -2220,8 +2330,8 @@
       shiny::textInput(ns("col_concept_ids"), "Column concept IDs (optional)",
                        placeholder = "comma-separated"),
       shiny::p(class = "text-muted small",
-        "Filtra los ejes por conceptos (p.ej. los measurement_concept_id ",
-        "de unos antibióticos) para el antibiograma."),
+        "Filter the axes by concepts (e.g. the measurement_concept_id ",
+        "of a few antibiotics) for the antibiogram."),
       shiny::radioButtons(ns("by"), "Count",
         choices = c("Distinct persons" = "persons", "Records" = "records"),
         selected = "persons"),
@@ -2266,20 +2376,30 @@
         choices = c("(none)" = "", cols))
     }, ignoreInit = TRUE)
 
+    has_run <- shiny::reactiveVal(FALSE)
     shiny::observeEvent(input$run_btn, {
       shiny::req(input$table, input$row, input$col)
+      has_run(TRUE)
       scope <- state$scope %||% "per_site"
       policy <- state$pooling_policy %||% "strict"
       strat <- if (nzchar(input$stratify_by %||% "")) input$stratify_by else NULL
       row_cid <- .parse_ids(input$row_concept_ids %||% "")
       col_cid <- .parse_ids(input$col_concept_ids %||% "")
+      tbl <- input$table; rw <- input$row; cl <- input$col
+      by <- input$by %||% "persons"
+      res_rv(NULL)
+      .defer_after_flush(session, {
       shiny::withProgress(message = "Building cross-tab...", value = 0.4, {
         res <- tryCatch(
-          ds.omop.crosstab(table = input$table, row = input$row, col = input$col,
-            by = input$by %||% "persons", stratify_by = strat,
-            row_concept_id = row_cid, col_concept_id = col_cid,
-            scope = .backend_scope(scope), pooling_policy = policy,
-            symbol = state$symbol),
+          .cached_call(state,
+            list(fn = "crosstab", table = tbl, row = rw, col = cl, by = by,
+                 stratify_by = strat %||% "", row_cid = row_cid %||% "",
+                 col_cid = col_cid %||% "", scope = scope, policy = policy),
+            function() ds.omop.crosstab(table = tbl, row = rw, col = cl,
+              by = by, stratify_by = strat,
+              row_concept_id = row_cid, col_concept_id = col_cid,
+              scope = .backend_scope(scope), pooling_policy = policy,
+              symbol = state$symbol)),
           error = function(e) {
             shiny::showNotification(.clean_ds_error(e), type = "error"); NULL
           })
@@ -2288,25 +2408,48 @@
         }
         res_rv(res)
       })
+      })
     })
 
     # Pick the display object: pooled list when scoped pooled, else first site.
+    # When strict pooling suppressed the whole pooled matrix, fall back to the
+    # first available per-site matrix (disclosure-safe) and flag it.
     .ct_obj <- shiny::reactive({
       res <- res_rv()
       if (is.null(res)) return(NULL)
       scope <- state$scope %||% "per_site"
-      if (identical(scope, "pooled") && !is.null(res$pooled)) return(res$pooled)
       ps <- res$per_site
-      if (length(ps) == 0) return(NULL)
-      srvs <- .resolve_servers(ps, state$selected_servers)
-      ps[[if (length(srvs) > 0) srvs[1] else names(ps)[1]]]
+      .first_site <- function() {
+        if (length(ps) == 0) return(NULL)
+        srvs <- .resolve_servers(ps, state$selected_servers)
+        ps[[if (length(srvs) > 0) srvs[1] else names(ps)[1]]]
+      }
+      if (identical(scope, "pooled")) {
+        pooled <- res$pooled
+        ok <- !is.null(pooled) && is.list(pooled) &&
+          ((!is.null(pooled$counts) && any(!is.na(pooled$counts))) ||
+           isTRUE(pooled$stratified))
+        if (ok) return(pooled)
+        alt <- .first_site()
+        if (!is.null(alt)) attr(alt, "pooled_fallback") <- TRUE
+        return(alt)
+      }
+      .first_site()
     })
 
     output$header <- shiny::renderUI({
       obj <- .ct_obj()
       if (is.null(obj)) {
+        if (!isTRUE(has_run())) {
+          return(.empty_state_ui("table-cells", "No cross-tab",
+            "Pick a table and two columns, then click Run."))
+        }
         return(.empty_state_ui("table-cells", "No cross-tab",
-          "Pick a table and two columns, then click Run."))
+          "No cells above the disclosure threshold for this selection."))
+      }
+      if (isTRUE(attr(obj, "pooled_fallback"))) {
+        return(.pooled_fallback_banner(
+          structure(data.frame(), pooled_fallback = TRUE)))
       }
       if (is.list(obj) && isTRUE(obj$stratified)) {
         return(shiny::p(class = "text-muted small mb-2",
@@ -2399,11 +2542,16 @@
       shiny::req(input$table)
       scope <- state$scope %||% "per_site"
       policy <- state$pooling_policy %||% "strict"
+      tbl <- input$table
+      res_rv(NULL)
+      .defer_after_flush(session, {
       shiny::withProgress(message = "Computing missingness...", value = 0.4, {
         res <- tryCatch(
-          ds.omop.missingness(table = input$table,
-            scope = .backend_scope(scope), pooling_policy = policy,
-            symbol = state$symbol),
+          .cached_call(state,
+            list(fn = "missingness", table = tbl, scope = scope, policy = policy),
+            function() ds.omop.missingness(table = tbl,
+              scope = .backend_scope(scope), pooling_policy = policy,
+              symbol = state$symbol)),
           error = function(e) {
             shiny::showNotification(.clean_ds_error(e), type = "error"); NULL
           })
@@ -2411,6 +2559,7 @@
           state$script_lines <- c(state$script_lines, res$meta$call_code)
         }
         res_rv(res)
+      })
       })
     })
 
@@ -2518,12 +2667,15 @@
                           class = "btn-success text-white w-100 mt-1")
     ),
     shiny::uiOutput(ns("header")),
+    shiny::uiOutput(ns("no_values_msg")),
     bslib::card(full_screen = TRUE,
       bslib::card_header("Numeric value statistics (no min/max — DataSHIELD-safe)"),
-      bslib::card_body(DT::DTOutput(ns("numeric_dt")))),
+      bslib::card_body(.with_spinner(DT::DTOutput(ns("numeric_dt")),
+                                     caption = "Running query…"))),
     bslib::card(full_screen = TRUE,
       bslib::card_header("Categorical value counts"),
-      bslib::card_body(DT::DTOutput(ns("categorical_dt"))))
+      bslib::card_body(.with_spinner(DT::DTOutput(ns("categorical_dt")),
+                                     caption = "Running query…")))
   )
 }
 
@@ -2531,6 +2683,7 @@
 .mod_explore_concept_summary_server <- function(id, state, parent_session = NULL) {
   shiny::moduleServer(id, function(input, output, session) {
     res_rv <- shiny::reactiveVal(NULL)
+    value_cols <- shiny::reactiveVal(NULL)
     picked_concept <- .concept_picker_server("concept", state)
 
     shiny::observe({
@@ -2549,9 +2702,21 @@
         cn[grepl("value_as_number$|value_as_concept_id$|^quantity$|^days_supply$",
                  cn, ignore.case = TRUE)]
       }, error = function(e) character(0))
+      value_cols(cols)
       shiny::updateSelectInput(session, "value_column",
                                choices = c("(auto-detect)" = "", cols))
     }, ignoreInit = TRUE)
+
+    # Explicit guidance when the chosen table has no value columns to summarise.
+    output$no_values_msg <- shiny::renderUI({
+      vc <- value_cols()
+      if (is.null(vc) || length(vc) > 0) return(NULL)
+      shiny::div(class = "alert alert-info py-2",
+        shiny::icon("circle-info"),
+        " This table has no value columns (value_as_number / ",
+        "value_as_concept_id) to summarise. Concept Summary applies to ",
+        "tables such as measurement and observation.")
+    })
 
     shiny::observeEvent(input$run_btn, {
       shiny::req(input$table)
@@ -2562,16 +2727,29 @@
         return()
       }
       col <- if (nzchar(input$value_column %||% "")) input$value_column else NULL
+      tbl <- input$table
+      # Honor the sidebar scope/policy instead of hardcoding pooled (which made
+      # categorical show only all-site-common values and numeric quantiles NULL).
+      scope <- state$scope %||% "per_site"
+      policy <- state$pooling_policy %||% "strict"
+      res_rv(NULL)
+      .defer_after_flush(session, {
       shiny::withProgress(message = "Querying concept summary…", value = 0.4, {
         res <- tryCatch(
-          ds.omop.concept.summary(table = input$table, concept_id = cid,
-                                  column = col, scope = "pooled",
-                                  symbol = state$symbol),
+          .cached_call(state,
+            list(fn = "concept.summary", table = tbl, concept_id = cid,
+                 column = col %||% "", scope = scope, policy = policy),
+            function() ds.omop.concept.summary(table = tbl, concept_id = cid,
+                                    column = col,
+                                    scope = .backend_scope(scope),
+                                    pooling_policy = policy,
+                                    symbol = state$symbol)),
           error = function(e) {
             shiny::showNotification(.clean_ds_error(e), type = "error")
             NULL
           })
         res_rv(res)
+      })
       })
     })
 
@@ -2613,13 +2791,16 @@
     })
 
     output$numeric_dt <- DT::renderDT({
-      df <- .cs_numeric_table(res_rv(), "pooled")
+      # Honor the sidebar scope; .cs_pick_scope falls back to a per-site slice
+      # when the pooled element is NULL (pooled numeric quantiles are NULL by
+      # design), so the table is populated under either scope.
+      df <- .cs_numeric_table(res_rv(), state$scope %||% "per_site")
       if (is.null(df)) return(NULL)
       .explore_dt(df, page_length = 10L, selection = "none")
     })
 
     output$categorical_dt <- DT::renderDT({
-      cc <- .cs_categorical_table(res_rv(), "pooled")
+      cc <- .cs_categorical_table(res_rv(), state$scope %||% "per_site")
       if (is.null(cc)) return(NULL)
       val <- if ("n" %in% names(cc)) "n" else NULL
       .explore_dt(cc, default_sort = val, selection = "none",

--- a/R/studio_overview.R
+++ b/R/studio_overview.R
@@ -15,19 +15,19 @@
       fixed_width = FALSE,
       bslib::value_box(
         title = "Servers",
-        value = shiny::textOutput(ns("kpi_servers")),
+        value = .with_spinner(shiny::textOutput(ns("kpi_servers"))),
         showcase = fontawesome::fa_i("server"),
         theme = "primary", full_screen = FALSE
       ),
       bslib::value_box(
         title = "Common Tables",
-        value = shiny::textOutput(ns("kpi_tables")),
+        value = .with_spinner(shiny::textOutput(ns("kpi_tables"))),
         showcase = fontawesome::fa_i("table"),
         theme = "info", full_screen = FALSE
       ),
       bslib::value_box(
         title = "Total Persons",
-        value = shiny::textOutput(ns("kpi_persons")),
+        value = .with_spinner(shiny::textOutput(ns("kpi_persons"))),
         showcase = fontawesome::fa_i("users"),
         theme = "success", full_screen = FALSE
       )
@@ -40,7 +40,8 @@
                           class = "btn-sm btn-outline-primary")
     ),
     # --- Server cards (one per server) ---
-    shiny::uiOutput(ns("server_cards")),
+    .with_spinner(shiny::uiOutput(ns("server_cards")),
+                  caption = "Loading servers…"),
     # --- System Notifications ---
     shiny::uiOutput(ns("notifications_section")),
     # --- Data Quality Section ---
@@ -57,7 +58,8 @@
       ),
       bslib::card_body(
         shiny::uiOutput(ns("coverage_server_ui")),
-        shiny::uiOutput(ns("coverage_content"))
+        .with_spinner(shiny::uiOutput(ns("coverage_content")),
+                      caption = "Loading coverage…")
       )
     ),
     bslib::card(
@@ -81,7 +83,8 @@
             shiny::uiOutput(ns("miss_server_ui"))
           )
         ),
-        shiny::uiOutput(ns("miss_content"))
+        .with_spinner(shiny::uiOutput(ns("miss_content")),
+                      caption = "Loading missingness…")
       )
     )
   )

--- a/R/studio_sidebar.R
+++ b/R/studio_sidebar.R
@@ -45,7 +45,7 @@
           shiny::radioButtons(ns("pooling_policy"), "Pooling Policy",
             choices = c("Strict" = "strict",
                         "Best Effort" = "pooled_only_ok"),
-            selected = "strict", inline = TRUE)
+            selected = "pooled_only_ok", inline = TRUE)
         )
       ),
 

--- a/man/ds.omop.concept.summary.Rd
+++ b/man/ds.omop.concept.summary.Rd
@@ -9,6 +9,7 @@ ds.omop.concept.summary(
   concept_id,
   column = NULL,
   scope = c("per_site", "pooled"),
+  pooling_policy = "strict",
   symbol = "omop",
   conns = NULL
 )
@@ -28,6 +29,12 @@ summarised.}
 
 \item{scope}{Character; \code{"per_site"} (default) or \code{"pooled"}.
 Passed through to the underlying calls.}
+
+\item{pooling_policy}{Character; \code{"strict"} (default) or
+\code{"pooled_only_ok"} (Best Effort). Passed through to the underlying
+value-counts, column-stats and quantile calls so that, when pooled,
+categories/values present on only some sites are summed across the
+available sites rather than suppressed.}
 
 \item{symbol}{Character; the session symbol (default: \code{"omop"}).}
 

--- a/man/ds.omop.value.histogram.Rd
+++ b/man/ds.omop.value.histogram.Rd
@@ -8,6 +8,7 @@ ds.omop.value.histogram(
   table,
   value_col,
   bins = 20L,
+  concept_id = NULL,
   cohort_table = NULL,
   window = NULL,
   scope = c("per_site", "pooled"),
@@ -24,6 +25,14 @@ ds.omop.value.histogram(
 \code{"value_as_number"}).}
 
 \item{bins}{Integer; the number of histogram bins (default: 20).}
+
+\item{concept_id}{Integer or NULL; optional concept ID to restrict rows to a
+single concept of the table before binning (e.g. \code{value_as_number}
+for one measurement concept). Default: NULL for all rows. The server
+applies the same disclosure controls to the concept-filtered population.
+Requires a dsOMOP server build with histogram concept scoping; older
+servers reject the argument (the Studio falls back to the box plot and
+percentile table, which are concept-scoped via the quantiles aggregate).}
 
 \item{cohort_table}{Character; name of a server-side cohort temp table
 for filtering, or NULL (default: NULL).}

--- a/tests/testthat/test-studio-explore-fixes.R
+++ b/tests/testthat/test-studio-explore-fixes.R
@@ -1,0 +1,109 @@
+# ==============================================================================
+# Test: Studio Explore fixes — disclosure-safe pooled fallback, session cache,
+# and the per-concept Numeric Distribution picker.
+# ==============================================================================
+
+.fix_result <- function(pooled) {
+  structure(list(
+    per_site = list(
+      nairobi = data.frame(concept_id = 1L, n_persons = 30L),
+      douala  = data.frame(concept_id = 2L, n_persons = 25L)),
+    pooled = pooled),
+    class = "dsomop_result")
+}
+
+test_that(".explore_display returns pooled untouched when it has data", {
+  res <- .fix_result(data.frame(concept_id = 1L, n_persons = 55L))
+  out <- .explore_display(res, "pooled", c("nairobi", "douala"),
+                          count_cols = "n_persons")
+  expect_equal(nrow(out), 1L)
+  expect_equal(out$n_persons, 55L)
+  expect_null(attr(out, "pooled_fallback"))
+})
+
+test_that(".explore_display falls back to per-site rows when pooled is empty", {
+  res <- .fix_result(data.frame(concept_id = integer(0), n_persons = integer(0)))
+  out <- .explore_display(res, "pooled", c("nairobi", "douala"),
+                          count_cols = "n_persons")
+  # Row-bound per-site view: both sites' rows, with a server column.
+  expect_true(is.data.frame(out))
+  expect_equal(nrow(out), 2L)
+  expect_true("server" %in% names(out))
+  expect_true(isTRUE(attr(out, "pooled_fallback")))
+})
+
+test_that(".explore_display falls back when pooled counts are all NA", {
+  res <- .fix_result(data.frame(concept_id = c(1L, 2L),
+                                n_persons = c(NA_integer_, NA_integer_)))
+  out <- .explore_display(res, "pooled", c("nairobi", "douala"),
+                          count_cols = "n_persons")
+  expect_true(isTRUE(attr(out, "pooled_fallback")))
+  expect_equal(nrow(out), 2L)
+})
+
+test_that(".explore_display does not fall back under per_site scope", {
+  res <- .fix_result(NULL)
+  out <- .explore_display(res, "per_site", "nairobi", count_cols = "n_persons")
+  expect_equal(out$n_persons, 30L)
+  expect_null(attr(out, "pooled_fallback"))
+})
+
+test_that(".pooled_fallback_banner only renders on the fallback flag", {
+  plain <- data.frame(a = 1)
+  expect_null(.pooled_fallback_banner(plain))
+  flagged <- structure(data.frame(a = 1), pooled_fallback = TRUE)
+  html <- as.character(.pooled_fallback_banner(flagged))
+  expect_true(grepl("Strict pooling suppressed", html))
+  expect_true(grepl("Best Effort", html))
+})
+
+test_that(".cache_key is order-independent and NULL-sensitive", {
+  k1 <- .cache_key(list(fn = "f", table = "m", concept_id = 5L))
+  k2 <- .cache_key(list(concept_id = 5L, table = "m", fn = "f"))
+  expect_identical(k1, k2)
+  k_null <- .cache_key(list(fn = "f", table = "m", concept_id = NULL))
+  k_set  <- .cache_key(list(fn = "f", table = "m", concept_id = 5L))
+  expect_false(identical(k_null, k_set))
+})
+
+test_that(".cached_call memoises and keys on the selected servers", {
+  st <- list(query_cache = new.env(parent = emptyenv()),
+             selected_servers = c("nairobi", "douala"), symbol = "omop")
+  n <- 0L
+  compute <- function() { n <<- n + 1L; list(v = n) }
+  r1 <- .cached_call(st, list(fn = "f", table = "m"), compute)
+  r2 <- .cached_call(st, list(fn = "f", table = "m"), compute)
+  expect_identical(r1, r2)
+  expect_equal(n, 1L)                         # second call is a cache hit
+  # Different server selection -> different key -> recompute.
+  st$selected_servers <- c("nairobi")
+  r3 <- .cached_call(st, list(fn = "f", table = "m"), compute)
+  expect_equal(n, 2L)
+  expect_equal(r3$v, 2L)
+})
+
+test_that(".cached_call does not cache NULL results", {
+  st <- list(query_cache = new.env(parent = emptyenv()),
+             selected_servers = "nairobi", symbol = "omop")
+  n <- 0L
+  compute <- function() { n <<- n + 1L; NULL }
+  .cached_call(st, list(fn = "f"), compute)
+  .cached_call(st, list(fn = "f"), compute)
+  expect_equal(n, 2L)                          # NULL never cached -> recompute
+})
+
+test_that("Numeric Distribution UI embeds a required concept picker", {
+  html <- as.character(.mod_explore_numeric_ui("num"))
+  # Concept picker is namespaced under explore-numeric-concept-*
+  expect_true(grepl("num-concept-search_term", html))
+  expect_true(grepl("Concept \\(required\\)", html))
+  expect_true(grepl("Heart rate", html))       # guidance example
+})
+
+test_that("ds.omop.value.histogram exposes a concept_id argument", {
+  expect_true("concept_id" %in% names(formals(ds.omop.value.histogram)))
+})
+
+test_that("ds.omop.concept.summary threads pooling_policy", {
+  expect_true("pooling_policy" %in% names(formals(ds.omop.concept.summary)))
+})


### PR DESCRIPTION
## Summary
Fixes the Studio Explore tabs that rendered **blank** + UX issues found in a live tab-by-tab audit.

- **Critical reactive bug**: Prevalence / Value Ranking / Numeric Distribution were empty because the deferred query (`.defer_after_flush` → `session$onFlushed`) read reactiveValues (`query_cache`, `selected_servers`, `symbol`) **outside a reactive consumer** → "Can't access reactive value … outside of reactive consumer". Fixed by evaluating the deferred block under `shiny::isolate()`.
- Default pooling policy → **Best Effort** (strict over-suppressed on the small federation).
- `shinycssloaders` Suggests → **Imports** so per-Run spinners render on a default install.
- Numeric Distribution is **per-concept** (concept picker → `concept_id`); Value Ranking concept filter.
- Cross-tab heatmap **guards all-NA** (no plotly crash on a fully-suppressed pooled 2-way table) + "switch to Per Site" placeholder.

## Test plan
- [x] Full client suite **474 / 0**
- [x] Live tab-by-tab Selenium audit (public federation): Prevalence MALE 57/FEMALE 43, Value Ranking rhythms, Numeric box+quantiles, Cross-tab no crash, Builder no clear-recipe modal — all render