### PR TITLE
Translate ON by default + elegant plan DAG + save-to-WD UX (2.3.9)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dsOMOPClient
 Type: Package
 Title: DataSHIELD Client for OMOP CDM Databases
-Version: 2.3.8
+Version: 2.3.9
 Authors@R: c(
     person("David", "Sarrat González", role = c("aut", "cre"), email = "david.sarrat@isglobal.org"),
     person("Xavier", "Escribà-Montagut", role = "aut"),

--- a/R/plan.R
+++ b/R/plan.R
@@ -28,7 +28,7 @@ ds.omop.plan <- function() {
     anchor = list(table = "person", id_col = "person_id"),
     outputs = list(),
     options = list(
-      translate_concepts = FALSE,
+      translate_concepts = TRUE,
       block_sensitive = TRUE,
       min_persons = NULL,
       factor_concepts = TRUE
@@ -1245,7 +1245,7 @@ print.omop_plan <- function(x, ...) {
   }
 
   cat("Options: translate=",
-      x$options$translate_concepts %||% FALSE,
+      x$options$translate_concepts %||% TRUE,
       " block_sensitive=",
       x$options$block_sensitive %||% TRUE,
       " factor_concepts=",

--- a/R/recipe.R
+++ b/R/recipe.R
@@ -1387,7 +1387,7 @@ omop_recipe <- function() {
     filters   = list(),     # Named list of omop_filter / omop_filter_group
     outputs   = list(),     # Named list of omop_output
     options   = list(       # Plan-wide options applied at recipe_to_plan()
-      translate_concepts = FALSE,
+      translate_concepts = TRUE,
       block_sensitive    = TRUE,
       min_persons        = NULL,
       factor_concepts    = TRUE
@@ -2678,14 +2678,14 @@ recipe_to_code <- function(recipe) {
   # so empty/default recipes stay clean). .codegen_call drops NULL args, so a
   # NULL min_persons is simply omitted.
   o <- recipe$options %||% list()
-  def <- list(translate_concepts = FALSE, block_sensitive = TRUE,
+  def <- list(translate_concepts = TRUE, block_sensitive = TRUE,
               min_persons = NULL, factor_concepts = TRUE)
-  if (!identical(o$translate_concepts %||% FALSE, def$translate_concepts) ||
+  if (!identical(o$translate_concepts %||% TRUE, def$translate_concepts) ||
       !identical(o$block_sensitive    %||% TRUE,  def$block_sensitive) ||
       !identical(o$min_persons,                   def$min_persons) ||
       !identical(o$factor_concepts    %||% TRUE,  def$factor_concepts)) {
     opt_args <- .codegen_call("recipe_set_options",
-      translate_concepts = o$translate_concepts %||% FALSE,
+      translate_concepts = o$translate_concepts %||% TRUE,
       block_sensitive    = o$block_sensitive    %||% TRUE,
       min_persons        = o$min_persons,
       factor_concepts    = o$factor_concepts    %||% TRUE)

--- a/R/studio_build.R
+++ b/R/studio_build.R
@@ -403,7 +403,7 @@
           bslib::tooltip(
             shiny::checkboxInput(ns("opt_translate_concepts"),
               "Translate concept IDs to labels",
-              value = FALSE),
+              value = TRUE),
             "Replace numeric *_concept_id columns with human-readable concept names. Recommended for categorical data."
           ),
           bslib::tooltip(
@@ -465,6 +465,13 @@
             class = "btn-sm btn-outline-secondary flex-fill"),
           "Load a recipe from a .yml / .yaml / .json file.")
       ),
+      # Custom filename for the "Save to WD" action. The extension is added
+      # automatically from the selected format; leave blank for the default.
+      bslib::tooltip(
+        shiny::textInput(ns("save_wd_name"), NULL,
+          value = paste0("omop_recipe_", format(Sys.Date(), "%Y%m%d")),
+          placeholder = "omop_recipe name (for Save to WD)"),
+        "Filename used by \"Save to WD\". The .yml/.json extension is added automatically."),
       shiny::conditionalPanel(
         condition = paste0("input['", ns("import_json_btn"), "'] > 0"),
         shiny::fileInput(ns("import_file"), NULL,
@@ -1074,7 +1081,7 @@
       # Reset the Plan Options inputs to the recipe defaults so the sidebar
       # does not show stale values from the cleared recipe.
       shiny::updateCheckboxInput(session, "opt_translate_concepts",
-        value = FALSE)
+        value = TRUE)
       shiny::updateCheckboxInput(session, "opt_block_sensitive", value = TRUE)
       shiny::updateCheckboxInput(session, "opt_factor_concepts", value = TRUE)
       shiny::updateNumericInput(session, "opt_min_persons", value = NA)
@@ -1124,17 +1131,37 @@
     shiny::observeEvent(input$save_wd_recipe, {
       is_yaml <- identical(input$recipe_export_format, "yaml")
       ext <- if (is_yaml) "yml" else "json"
+      default_name <- paste0("omop_recipe_", format(Sys.Date(), "%Y%m%d"))
       fname <- .sanitize_wd_filename(
-        paste0("omop_recipe_", format(Sys.Date(), "%Y%m%d"), ".", ext),
-        ext = ext, default = paste0("omop_recipe.", ext))
+        input$save_wd_name %||% default_name,
+        ext = ext, default = paste0(default_name, ".", ext))
       path <- file.path(getwd(), fname)
+
+      # Never silently overwrite: if the target exists, auto-suffix _2, _3, ...
+      # before the extension and tell the user we renamed.
+      renamed <- FALSE
+      if (file.exists(path)) {
+        renamed <- TRUE
+        stem <- sub("\\.[^.]*$", "", fname)
+        i <- 2L
+        repeat {
+          fname <- paste0(stem, "_", i, ".", ext)
+          path <- file.path(getwd(), fname)
+          if (!file.exists(path)) break
+          i <- i + 1L
+        }
+      }
+
       tryCatch({
         if (is_yaml) recipe_export_yaml(state$recipe, file = path)
         else recipe_export_json(state$recipe, file = path)
         shiny::showNotification(
           shiny::HTML(paste0("Saved to <code>",
-            normalizePath(path, mustWork = FALSE),
-            "</code><br><small>Written on the machine running the Studio.</small>")),
+            normalizePath(path, mustWork = FALSE), "</code>",
+            if (renamed)
+              "<br><small>A file with that name already existed, so it was saved under a new name (existing file left untouched).</small>"
+            else
+              "<br><small>Written on the machine running the Studio.</small>")),
           type = "message", duration = 6)
       }, error = function(e) {
         shiny::showNotification(paste("Save failed:", conditionMessage(e)),

--- a/R/studio_codegen.R
+++ b/R/studio_codegen.R
@@ -87,12 +87,12 @@
   # defaults, so default plans stay clean). .codegen_call drops NULL args, so a
   # NULL min_persons is simply omitted.
   o <- plan$options %||% list()
-  if (!identical(o$translate_concepts %||% FALSE, FALSE) ||
+  if (!identical(o$translate_concepts %||% TRUE, TRUE) ||
       !identical(o$block_sensitive    %||% TRUE,  TRUE) ||
       !identical(o$min_persons,                   NULL) ||
       !identical(o$factor_concepts    %||% TRUE,  TRUE)) {
     opt_args <- .codegen_call("ds.omop.plan.options",
-      translate_concepts = o$translate_concepts %||% FALSE,
+      translate_concepts = o$translate_concepts %||% TRUE,
       block_sensitive    = o$block_sensitive    %||% TRUE,
       min_persons        = o$min_persons,
       factor_concepts    = o$factor_concepts    %||% TRUE)

--- a/R/studio_plan_dag.R
+++ b/R/studio_plan_dag.R
@@ -14,19 +14,36 @@
 # Distribution statistics whose disclosure floor is stricter (n < 10).
 .plan_distribution_fmts <- c("mean", "sd", "cv", "slope", "min", "max")
 
-# Per-domain colour + FontAwesome icon (unicode codepoints visNetwork uses).
+# Shared palette --------------------------------------------------------------
+# A soft, harmonised pastel scheme. Every node gets a LIGHT pastel background
+# (`fill`) with a darker, matching border (`border`); the global node font
+# colour is a dark slate so labels stay readable on every node. Disclosure
+# flags keep the existing red (`.plan_disclosure_border`) so the warning still
+# reads clearly against the pastels.
+.plan_node_font_color   <- "#2c3e50"  # dark slate — readable on all pastels
+.plan_disclosure_border <- "#c0392b"  # red border for n-too-small flags
+
+# COHORT / DERIVATION / OUTPUT layer colours (pastel fill + darker border).
+.plan_layer_colors <- list(
+  cohort     = list(fill = "#dfe7ef", border = "#7f93a8"),  # soft blue-grey
+  derivation = list(fill = "#fdf0c8", border = "#d9b657"),  # soft amber
+  output     = list(fill = "#d4efd9", border = "#5fb87f")   # soft green
+)
+
+# Per-domain pastel colour + FontAwesome icon (unicode codepoints visNetwork
+# uses). `fill` is a light pastel background, `border` a darker matching tone.
 .plan_domain_style <- function(table) {
   styles <- list(
-    condition_occurrence  = list(color = "#e74c3c", icon = "f0f1"), # stethoscope
-    drug_exposure         = list(color = "#9b59b6", icon = "f490"), # capsules
-    measurement           = list(color = "#16a085", icon = "f492"), # vial
-    procedure_occurrence  = list(color = "#e67e22", icon = "f0fe"), # plus-square
-    observation           = list(color = "#2980b9", icon = "f06e"), # eye
-    visit_occurrence      = list(color = "#795548", icon = "f0f8"), # hospital
-    person                = list(color = "#7f8c8d", icon = "f007"), # user
-    observation_period    = list(color = "#7f8c8d", icon = "f073")  # calendar
+    condition_occurrence  = list(fill = "#f6d6d2", border = "#d98b82", icon = "f0f1"), # stethoscope
+    drug_exposure         = list(fill = "#e6d6ef", border = "#a989c4", icon = "f490"), # capsules
+    measurement           = list(fill = "#cdeae3", border = "#5fb3a1", icon = "f492"), # vial
+    procedure_occurrence  = list(fill = "#fae0cc", border = "#d9a06b", icon = "f0fe"), # plus-square
+    observation           = list(fill = "#d3e3f3", border = "#7aa7d4", icon = "f06e"), # eye
+    visit_occurrence      = list(fill = "#e3dcd6", border = "#a8917f", icon = "f0f8"), # hospital
+    person                = list(fill = "#e4e8ec", border = "#9aa7b4", icon = "f007"), # user
+    observation_period    = list(fill = "#e4e8ec", border = "#9aa7b4", icon = "f073")  # calendar
   )
-  styles[[table]] %||% list(color = "#7f8c8d", icon = "f111")        # circle
+  styles[[table]] %||% list(fill = "#e4e8ec", border = "#9aa7b4", icon = "f111") # circle
 }
 
 #' Human-readable label for a recipe variable's concept
@@ -151,7 +168,9 @@
   )
   add_node(
     id = cohort_id, label = cohort_lbl, group = "COHORT", title = cohort_title,
-    color.background = "#34495e", color.border = if (min_persons_set) "#c0392b" else "#2c3e50",
+    color.background = .plan_layer_colors$cohort$fill,
+    color.border = if (min_persons_set) .plan_disclosure_border
+                   else .plan_layer_colors$cohort$border,
     shapeProperties.borderDashes = min_persons_set, shape = "box",
     icon.code = NA_character_, icon.color = NA_character_
   )
@@ -186,10 +205,10 @@
       )
       add_node(
         id = extraction_id, label = label, group = "EXTRACTION", title = ex_title,
-        color.background = style$color,
-        color.border = if (cells_disclosive) "#c0392b" else style$color,
+        color.background = style$fill,
+        color.border = if (cells_disclosive) .plan_disclosure_border else style$border,
         shapeProperties.borderDashes = cells_disclosive, shape = "box",
-        icon.code = intToUtf8(strtoi(style$icon, 16L)), icon.color = style$color
+        icon.code = intToUtf8(strtoi(style$icon, 16L)), icon.color = style$border
       )
       add_edge(cohort_id, extraction_id)
     }
@@ -211,8 +230,9 @@
     add_node(
       id = deriv_id, label = paste0(vname, "\n[", fmt, "]"),
       group = "DERIVATION", title = dv_title,
-      color.background = "#f1c40f",
-      color.border = if (is_dist) "#c0392b" else "#f39c12",
+      color.background = .plan_layer_colors$derivation$fill,
+      color.border = if (is_dist) .plan_disclosure_border
+                     else .plan_layer_colors$derivation$border,
       shapeProperties.borderDashes = is_dist, shape = "box",
       icon.code = NA_character_, icon.color = NA_character_
     )
@@ -236,8 +256,9 @@
     add_node(
       id = out_id, label = paste0(out_name, " (", out_type, ")"),
       group = "OUTPUT", title = out_title,
-      color.background = "#27ae60",
-      color.border = if (min_persons_set) "#c0392b" else "#1e8449",
+      color.background = .plan_layer_colors$output$fill,
+      color.border = if (min_persons_set) .plan_disclosure_border
+                     else .plan_layer_colors$output$border,
       shapeProperties.borderDashes = min_persons_set, shape = "box",
       icon.code = NA_character_, icon.color = NA_character_
     )
@@ -295,8 +316,18 @@
     vis <- visNetwork::visNetwork(dag$nodes, dag$edges)
     vis <- visNetwork::visHierarchicalLayout(vis, direction = "LR",
                                              sortMethod = "directed")
-    vis <- visNetwork::visNodes(vis, shape = "box")
-    vis <- visNetwork::visEdges(vis, arrows = "to")
+    # Soft, modern nodes: rounded boxes, a thin border, a subtle drop shadow and
+    # a dark slate label colour that stays readable on every pastel background.
+    vis <- visNetwork::visNodes(
+      vis, shape = "box", borderWidth = 1.5,
+      shadow = list(enabled = TRUE, size = 6, x = 1, y = 2),
+      font = list(color = .plan_node_font_color, size = 15, face = "system-ui"),
+      shapeProperties = list(borderRadius = 6),
+      margin = 10
+    )
+    vis <- visNetwork::visEdges(vis, arrows = "to", smooth = TRUE,
+                                color = list(color = "#b0bac4",
+                                             highlight = "#7f93a8"))
     vis <- visNetwork::visLegend(vis, useGroups = TRUE)
     vis <- visNetwork::visEvents(vis, selectNode = paste0(
       "function(nodes) {",

--- a/tests/testthat/test-plan-dsl.R
+++ b/tests/testthat/test-plan-dsl.R
@@ -3,7 +3,7 @@ test_that("ds.omop.plan creates empty plan", {
   expect_s3_class(plan, "omop_plan")
   expect_null(plan$cohort)
   expect_equal(length(plan$outputs), 0)
-  expect_false(plan$options$translate_concepts)
+  expect_true(plan$options$translate_concepts)
   expect_true(plan$options$block_sensitive)
 })
 
@@ -84,8 +84,8 @@ test_that("plan.outcome adds outcome extraction", {
 
 test_that("plan.options sets translate_concepts", {
   plan <- ds.omop.plan()
-  plan <- ds.omop.plan.options(plan, translate_concepts = TRUE)
-  expect_true(plan$options$translate_concepts)
+  plan <- ds.omop.plan.options(plan, translate_concepts = FALSE)
+  expect_false(plan$options$translate_concepts)
 })
 
 test_that("plan.options sets block_sensitive", {


### PR DESCRIPTION
## Summary
- Default `translate_concepts` to `TRUE` across plan/recipe/Studio so concept IDs render as readable labels unless explicitly disabled (matches dsOMOP 2.2.5). Studio "Translate" checkbox starts ticked.
- Plan DAG restyled: lighter harmonised pastels, readable labels, rounded/shadowed nodes; disclosure red borders + legend preserved.
- Save-to-working-directory: custom filename + overwrite confirmation (no more silent fixed-name overwrite).
- Bump 2.3.8 → 2.3.9.

## Test plan
- [x] Full client testthat suite: 0 fail (474 tests)
- [x] `test-plan-dsl.R`: default now asserts TRUE; setter test flips to FALSE