### PR TITLE
Fix OHDSI tab disable handlers after rename (2.4.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dsOMOPClient
 Type: Package
 Title: DataSHIELD Client for OMOP CDM Databases
-Version: 2.4.2
+Version: 2.4.3
 Authors@R: c(
     person("David", "Sarrat González", role = c("aut", "cre"), email = "david.sarrat@isglobal.org"),
     person("Xavier", "Escribà-Montagut", role = "aut"),
@@ -10,8 +10,8 @@ Description: Client-side DataSHIELD package for interacting with OMOP CDM
     databases. Provides an ergonomic plan-based API for safe data extraction,
     schema exploration, vocabulary operations, cohort management, feature
     engineering, and multi-server harmonization. Includes a recipe builder for
-    point-and-click cohort and feature construction, a curated query library
-    with auto-visualization, Achilles analytics integration, and OMOP Studio —
+    point-and-click cohort and feature construction, a curated query library,
+    Achilles analytics integration, and OMOP Studio —
     a full Shiny application for interactive federated data exploration.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/R/studio.R
+++ b/R/studio.R
@@ -151,8 +151,7 @@ ds.omop.studio <- function(symbol = "omop", launch.browser = TRUE, port = NULL) 
           Shiny.addCustomMessageHandler('toggleAchillesTab', function(data) {
             var tabs = document.querySelectorAll('#main_nav .nav-link, #main_nav .dropdown-item');
             tabs.forEach(function(tab) {
-              if (tab.textContent.trim().indexOf('Achilles') !== -1 &&
-                  tab.textContent.trim().indexOf('OHDSI') === -1) {
+              if (tab.getAttribute('data-value') === 'achilles_tab') {
                 if (data.disabled) {
                   tab.classList.add('achilles-disabled');
                   tab.setAttribute('title', data.tooltip || 'Run OHDSI Achilles on your CDM to enable this tab');
@@ -168,7 +167,7 @@ ds.omop.studio <- function(symbol = "omop", launch.browser = TRUE, port = NULL) 
           Shiny.addCustomMessageHandler('toggleOhdsiResultsTab', function(data) {
             var tabs = document.querySelectorAll('#main_nav .nav-link, #main_nav .dropdown-item');
             tabs.forEach(function(tab) {
-              if (tab.textContent.trim().indexOf('OHDSI Results') !== -1) {
+              if (tab.getAttribute('data-value') === 'ohdsi_results_tab') {
                 if (data.disabled) {
                   tab.classList.add('ohdsi-results-disabled');
                   tab.setAttribute('title', data.tooltip || 'No OHDSI result tables found');


### PR DESCRIPTION
The Analytics→OHDSI Tools / Achilles→Analysis / OHDSI Results→Data Quality rename left the JS toggle handlers matching old labels by textContent, so the disable/tooltip/click-block for unavailable tabs was dead. Match by stable data-value (achilles_tab/ohdsi_results_tab). Drop stale 'auto-visualization' from DESCRIPTION. Suite 0 fail (485).